### PR TITLE
feat: optimize holiday shifts with CP-SAT

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Run optimization pipeline and produce shift_summary.csv."""
+    root = Path(__file__).resolve().parent
+    (root / "output").mkdir(exist_ok=True)
+    scripts = ["optimize_1.py", "optimize_2.py", "optimize_3.py"]
+    for script in scripts:
+        try:
+            subprocess.run([sys.executable, str(root / script)], check=True)
+        except subprocess.CalledProcessError as exc:
+            print(f"Error while executing {script}: {exc}")
+            raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pipeline entrypoint `main.py` to run all optimization stages
- optimize holiday shift assignment in `optimize_3.py` using OR-Tools CP-SAT

## Testing
- `python main.py`
- `pytest` *(fails: rest day minimum, Saturday assignment for 久保, 御書 restricted shifts)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a08418088324b242f26ef6edccc5